### PR TITLE
Fix regex patterns in scala native

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.13"
-  val scalametaV  = "4.4.20+16-5a8c527e+20210616-1707-SNAPSHOT"
+  val scalametaV  = "4.4.22"
   val scalacheckV = "1.15.4"
   val coursier    = "1.0.3"
   val munitV      = "0.7.26"

--- a/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/PlatformCompat.scala
+++ b/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/PlatformCompat.scala
@@ -4,8 +4,6 @@ import java.util.regex.Pattern
 import scala.util.matching.Regex
 
 object PlatformCompat {
-  @inline
-  def fixRegex(reg: String) = reg
 
   @inline
   val trailingSpace =
@@ -19,7 +17,7 @@ object PlatformCompat {
     Pattern.compile("^/\\*\\h*+(?:\n\\h*+[*]*+\\h*+)?")
   @inline
   val mlcLineDelim =
-    Pattern.compile(PlatformCompat.fixRegex("\\h*+\n\\h*+[*]*+\\h*+"))
+    Pattern.compile("\\h*+\n\\h*+[*]*+\\h*+")
   @inline
   val mlcParagraphEnd = Pattern.compile("[.:!?=]$")
   @inline
@@ -46,13 +44,34 @@ object PlatformCompat {
 
   @inline
   def compileStripMarginPattern(pipe: Char) =
-    Pattern.compile(PlatformCompat.fixRegex(s"(?<=\n)\\h*+(?=\\${pipe})"))
+    Pattern.compile(s"(?<=\n)\\h*+(?=\\${pipe})")
 
   // see: https://ammonite.io/#Save/LoadSession
   @inline
-  val ammonitePattern: Regex = "(?:\\s*\\n@(?=\\s))+".r
+  private val ammonitePattern: Regex = "(?:\\s*\\n@(?=\\s))+".r
 
   @inline
   val stripMarginPattern =
     Pattern.compile("\n(\\h*+\\|)?([^\n]*+)")
+
+  @inline
+  def replaceAllStripMargin(
+      stripMarginPattern: Pattern,
+      text: String,
+      spaces: String,
+      pipe: Char
+  ): String =
+    stripMarginPattern.matcher(text).replaceAll(spaces)
+
+  @inline
+  def replaceAllLeadingAsterisk(
+      leadingAsteriskSpace: Pattern,
+      trimmed: String,
+      spaces: String
+  ): String =
+    leadingAsteriskSpace.matcher(trimmed).replaceAll(spaces)
+
+  @inline
+  def splitByAmmonitePattern(code: String): Array[String] =
+    ammonitePattern.split(code)
 }

--- a/scalafmt-core/native/src/main/scala/org/scalafmt/internal/PlatformCompat.scala
+++ b/scalafmt-core/native/src/main/scala/org/scalafmt/internal/PlatformCompat.scala
@@ -3,76 +3,207 @@ package org.scalafmt.internal
 import scala.util.matching.Regex
 import java.util.regex.Pattern
 
+/* Before text matching (?=re), after text matching (?<=re) 
+   and more are incompatible in Scala Native, so custom functions 
+   have to be used. 
+   https://github.com/google/re2/wiki/Syntax  */
+
 object PlatformCompat {
-  @inline
-  private def fixRegex(reg: String) = {
-    reg
-      .replace(
-        "\\h",
-        "[\t \u00A0\u1680\u180E\u2000-\u200A\u202F\u205F\u3000]"
-      )
+
+  /* Replaces '\\h', which is incompatible in Scala Native.
+     Does not check the correctness of the input regex string. */
+  private def fixHorizontalSpaceInRegex(reg: String) = {
+
+    @inline
+    def replacingInsideClass =
+      "\t \u00A0\u1680\u180E\u2000-\u200A\u202F\u205F\u3000"
+    
+    @inline
+    def replacingOutsideClass =
+      s"[$replacingInsideClass]"
+
+    val sb = new StringBuilder()
+    var isInClass = false
+    var isEscaped = false
+
+    for (char <- reg) {
+      char match {
+        case '\\' if !isEscaped =>
+          isEscaped = true
+        case 'h' if isEscaped =>
+          sb.append(
+            if (isInClass) replacingInsideClass
+            else replacingOutsideClass
+          )
+          isEscaped = false
+        case '[' if !isEscaped =>
+          sb.append('[')
+          isInClass = true
+        case ']' if !isEscaped =>
+          sb.append(']')
+          isInClass = false
+        case other =>
+          if (isEscaped) {
+            isEscaped = false
+            sb.append('\\')
+          }
+          sb.append(other)
+      }
+    }
+    sb.toString()
   }
 
   @inline
   val trailingSpace =
-    Pattern.compile(PlatformCompat.fixRegex("\\h+$"), Pattern.MULTILINE)
+    Pattern.compile(
+      PlatformCompat.fixHorizontalSpaceInRegex("\\h+$"),
+      Pattern.MULTILINE
+    )
 
   @inline
-  val slcDelim = Pattern.compile(PlatformCompat.fixRegex("\\h+"))
+  val slcDelim =
+    Pattern.compile(PlatformCompat.fixHorizontalSpaceInRegex("\\h+"))
 
   @inline
   val mlcHeader =
     Pattern.compile(
-      PlatformCompat.fixRegex("^/\\*\\h*(?:\n\\h*[*]*\\h*)?")
+      PlatformCompat.fixHorizontalSpaceInRegex("^/\\*\\h*(?:\n\\h*[*]*\\h*)?")
     )
   @inline
   val mlcLineDelim =
-    Pattern.compile(PlatformCompat.fixRegex("\\h*\n\\h*[*]*\\h+"))
+    Pattern.compile(
+      PlatformCompat.fixHorizontalSpaceInRegex("\\h*\n\\h*[*]*\\h*")
+    )
   @inline
   val mlcParagraphEnd = Pattern.compile("[.:!?=]$")
   @inline
   val mlcParagraphBeg = Pattern.compile("^(?:[-*@=]|\\d+[.:])")
 
-  
   @inline
   val leadingAsteriskSpace =
     Pattern.compile(
-      PlatformCompat.fixRegex("^\\h*([*][^*])"),
-      Pattern.MULTILINE// | Pattern.UNIX_LINES
+      PlatformCompat.fixHorizontalSpaceInRegex("\n\\h*[*][^*]"),
+      Pattern.MULTILINE
     )
   @inline
   val docstringLine =
     Pattern.compile(
-      PlatformCompat.fixRegex("^(?:\\h*\\*)?(\\h*)([^\\h\n]*?)\\h*$"),
-      Pattern.MULTILINE //| Pattern.UNIX_LINES
+      PlatformCompat.fixHorizontalSpaceInRegex("^(?:\\h*\\*)?(\\h*)(.*?)\\h*$"),
+      Pattern.MULTILINE
     )
 
   @inline
   val onelineDocstring = {
-    val empty = PlatformCompat.fixRegex("\\h*(\n\\h*(?:\\*\\h*)?)*")
+    val empty =
+      PlatformCompat.fixHorizontalSpaceInRegex("\\h*(\n\\h*(?:\\*\\h*)?)*")
     Pattern.compile(
-      PlatformCompat.fixRegex(
+      PlatformCompat.fixHorizontalSpaceInRegex(
         s"^/\\*\\*$empty([^*\n\\h](?:[^\n]*[^\n\\h])?)$empty\\*/$$"
       )
     )
   }
   @inline
   val docstringLeadingSpace =
-    Pattern.compile(PlatformCompat.fixRegex("^\\h+"))
+    Pattern.compile(PlatformCompat.fixHorizontalSpaceInRegex("^\\h+"))
 
   @inline
   def compileStripMarginPattern(pipe: Char) =
     Pattern.compile(
-      PlatformCompat.fixRegex(s"^\\h*"),
-      Pattern.MULTILINE // | Pattern.UNIX_LINES
+      PlatformCompat.fixHorizontalSpaceInRegex(s"\n+\\h*?\\${pipe}"),
+      Pattern.MULTILINE
     )
 
   // see: https://ammonite.io/#Save/LoadSession
   @inline
   val ammonitePattern: Regex =
     // lookahead is not support in native
-    "(?:\\s*\\n@\\s)+".r
+    "(?:\\s*\\n@)".r
 
+  @inline
   val stripMarginPattern =
-    Pattern.compile(PlatformCompat.fixRegex("\n(\\h*\\|)?([^\n]*)"))
+    Pattern.compile(
+      PlatformCompat.fixHorizontalSpaceInRegex("\n(\\h*\\|)?([^\n]*)"),
+      Pattern.MULTILINE
+    )
+
+  // startAfterPattern and endBeforePattern should be unique in basePattern
+  // basePattern = startAfterPattern + matched pattern + endBeforePattern
+  private def replaceAll(
+      basePattern: Pattern,
+      startAfterPattern: Pattern,
+      endBeforePattern: Pattern,
+      baseText: String,
+      replacingText: String
+  ): String = {
+    val sb = new StringBuilder()
+    val matcher = basePattern.matcher(baseText)
+    var currPosition = 0
+    while (matcher.find()) {
+      val start = matcher.start()
+      val end = matcher.end()
+
+      sb.append(baseText.substring(currPosition, start))
+
+      val subtext = baseText.substring(start, end)
+      val startAfterMatcher = startAfterPattern.matcher(subtext)
+      val endBeforeMatcher = endBeforePattern.matcher(subtext)
+
+      startAfterMatcher.find()
+      endBeforeMatcher.find()
+
+      sb.append(startAfterMatcher.group())
+      sb.append(replacingText)
+      sb.append(endBeforeMatcher.group())
+
+      currPosition = end
+    }
+
+    sb.append(baseText.substring(currPosition))
+    sb.toString()
+  }
+
+  def replaceAllStripMargin(
+      stripMarginPattern: Pattern,
+      text: String,
+      spaces: String,
+      pipe: Char
+  ): String = {
+    val startAfter = Pattern.compile("\n+")
+    val endBefore = Pattern.compile(s"\\${pipe}")
+
+    replaceAll(stripMarginPattern, startAfter, endBefore, text, spaces)
+  }
+
+  def replaceAllLeadingAsterisk(
+      leadingAsteriskSpace: Pattern,
+      trimmed: String,
+      spaces: String
+  ): String = {
+    val startAfter = Pattern.compile("\n")
+    val endBefore = Pattern.compile("([*][^*])")
+
+    replaceAll(leadingAsteriskSpace, startAfter, endBefore, trimmed, spaces)
+  }
+
+  def splitByAmmonitePattern(code: String): Array[String] = {
+    def whitespacePattern = Pattern.compile("\\s")
+    val actualMatches = ammonitePattern
+      .findAllMatchIn(code)
+      .filter(regexMatch =>
+        regexMatch.end < code.length && whitespacePattern
+          .matcher(Character.toString(code.charAt(regexMatch.end)))
+          .find()
+      )
+      .toArray
+
+    val res = new scala.collection.mutable.ArrayBuffer[String]()
+    var currPosition = 0
+    for (actualMatch <- actualMatches) {
+      if (currPosition != actualMatch.start)
+        res.append(code.substring(currPosition, actualMatch.start))
+      currPosition = actualMatch.end
+    }
+    res.append(code.substring(currPosition))
+    res.toArray
+  }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -7,7 +7,6 @@ import scala.meta.Input
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-import scala.util.matching.Regex
 
 import org.scalafmt.config.Config
 import org.scalafmt.Error.PreciseIncomplete
@@ -91,9 +90,6 @@ object Scalafmt {
     iter(Seq.empty)
   }
 
-  // see: https://ammonite.io/#Save/LoadSession
-  private val ammonitePattern: Regex = PlatformCompat.ammonitePattern
-
   private def doFormat(
       code: String,
       style: ScalafmtConfig,
@@ -103,7 +99,8 @@ object Scalafmt {
     doFormatOne(code, style, file, range)
   else {
     // XXX: we won't support ranges as we don't keep track of lines
-    val chunks = ammonitePattern.split(code)
+    // see: https://ammonite.io/#Save/LoadSession
+    val chunks = PlatformCompat.splitByAmmonitePattern(code)
     if (chunks.length <= 1) doFormatOne(code, style, file, range)
     else
       flatMapAll(chunks.iterator)(doFormatOne(_, style, file))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -407,7 +407,12 @@ class FormatWriter(formatOps: FormatOps) {
         }
         tupleOpt.fold(text) { case (pipe, indent) =>
           val spaces = getIndentation(indent)
-          getStripMarginPattern(pipe).matcher(text).replaceAll(spaces)
+          PlatformCompat.replaceAllStripMargin(
+            getStripMarginPattern(pipe),
+            text,
+            spaces,
+            pipe
+          )
         }
       }
 
@@ -589,8 +594,13 @@ class FormatWriter(formatOps: FormatOps) {
             sb.append(" */")
           } else {
             val trimmed = removeTrailingWhiteSpace(text)
-            // TODO ?
-            sb.append(leadingAsteriskSpace.matcher(trimmed).replaceAll(spaces+ "$1") )
+            sb.append(
+              PlatformCompat.replaceAllLeadingAsterisk(
+                leadingAsteriskSpace,
+                trimmed,
+                spaces
+              )
+            )
           }
         }
 
@@ -1425,7 +1435,8 @@ object FormatWriter {
 
   @inline
   private def getStripMarginPattern(pipe: Char) =
-    if (pipe == '|') leadingPipeSpace else PlatformCompat.compileStripMarginPattern(pipe)
+    if (pipe == '|') leadingPipeSpace
+    else PlatformCompat.compileStripMarginPattern(pipe)
 
   private val leadingPipeSpace = PlatformCompat.compileStripMarginPattern('|')
 


### PR DESCRIPTION
Now, all FormatTests should pass, at least for scalameta version 4.4.22 - for 4.4.23 and higher, there appear to be issues with both testsNative and testsJVM.